### PR TITLE
fix: break h1's to prevent x-overflow [Fixes #12]

### DIFF
--- a/app/paper/[slug]/page.tsx
+++ b/app/paper/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function Page({ params }: Props) {
           })}
         </time>
 
-        <h1 className="text-4xl font-bold tracking-[0.01em] md:text-5xl">
+        <h1 className="text-4xl font-bold tracking-[0.01em] break-all md:text-5xl">
           {title}
         </h1>
 

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function Page({ params }: Props) {
           })}
         </time>
 
-        <h1 className="text-4xl font-bold tracking-[0.01em] md:text-5xl">
+        <h1 className="text-4xl font-bold tracking-[0.01em] break-all md:text-5xl">
           {title}
         </h1>
 

--- a/app/talk/[slug]/page.tsx
+++ b/app/talk/[slug]/page.tsx
@@ -50,7 +50,7 @@ export default async function Page({ params }: Props) {
               })}
         </time>
 
-        <h1 className="text-4xl font-bold tracking-[0.01em] md:text-5xl">
+        <h1 className="text-4xl font-bold tracking-[0.01em] break-all md:text-5xl">
           {title}
         </h1>
 


### PR DESCRIPTION
## Description
- Applies `break-all` to posts/talks/papers `h1` elements
- Note: In markdown content, wrap long strings as-needed inside `<wbr></wbr>` (word-break) tags to force a word-break opportunity, e.g., `<wbr>0x1234567890123456789012345678901234567890</wbr>` to break this long uninterrupted string preventing x-overflow (cc: @casparschwa)